### PR TITLE
[Enhancement] Add contribution guides and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+# Ref:
+#  (1) https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#about-yaml-syntax-for-issue-forms
+#  (2) https://raw.githubusercontent.com/vercel/next.js/canary/.github/ISSUE_TEMPLATE/1.bug_report.yml
+#  (3) https://raw.githubusercontent.com/aio-libs/aiohttp/master/.github/ISSUE_TEMPLATE/bug_report.yml
+---
+name: 🐛 Bug Report
+description: Create a report to help us improve.
+labels: 'template: bug'
+assignees: 0xOlias
+body:
+- type: markdown
+  attributes:
+    value: |
+      **Thanks for taking the time to file a bug report!**
+
+      Verify first that your issue is not [already reported on GitHub][issue search].
+
+      _Please fill out the form below with as many precise
+      details as possible._
+
+      [issue search]: ../search?q=is%3Aissue&type=issues
+
+- type: dropdown
+  attributes:
+    label: Type of Issue
+    description: >-
+      deck-viewer is both a published dApp and community project.
+      For clarity, please select 'User' or 'Developer'.
+    multiple: false
+    options:
+    - User
+    - Developer
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Describe the Bug
+    description: >-
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: To Reproduce
+    description: >-
+      Describe the steps to reproduce this bug.
+    placeholder: |
+      1. Navigate to '...'
+      2. Then do '...'
+      3. The following error or unexpected behavior occurs: '...'
+  validations:
+    required: true
+
+- type: markdown
+  attributes:
+    value: Before posting the issue go through the steps you've written down to make sure the steps provided are detailed and clear.
+
+- type: markdown
+  attributes:
+    value: Contributors should be able to follow the steps provided in order to reproduce the bug.
+
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: |
+      A clear and concise description of what you expected to happen.
+      Screenshots can be provided in the issue body below.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Logs / Stack Traces
+    description: |
+      If applicable, add logs or stack traces to help explain your problem.
+      Paste the output of the steps above, including the commands or actions
+      and their output. Otherwise, write "N/A".
+    render: console
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: What version of Node.js are you using?
+    description:  |
+      If this is a bug found while contributing to the source code, please
+      include the node version you are using. Otherwise, write "N/A".
+    value: |
+      $ node --version
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: What operating system are you using?
+    description: You may select more than one.
+    options:
+      - label: macOS
+      - label: Windows
+      - label: Linux
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Additional Context
+    description: |
+      Add any other context about the problem here.
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Adventure Cards Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/Adventure-Cards/deck-viewer/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the Adventure Cards Code of Conduct
+      required: true
+...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false  # default: true
+contact_links:
+- name: 🛠 Adventure Cards Discord
+  url: https://discord.com/channels/883402804998307851/889931177350299698
+  about: Chat with us in "#🛠-buidl"
+- name: 🐦 Adventure Cards Twitter
+  url: https://twitter.com/0xadventures
+  about: Give us a shout-out on the bird app

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+# Ref:
+#  (1) https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#about-yaml-syntax-for-issue-forms
+#  (2) https://raw.githubusercontent.com/vercel/next.js/canary/.github/ISSUE_TEMPLATE/3.feature_request.yml
+#  (3) https://raw.githubusercontent.com/aio-libs/aiohttp/master/.github/ISSUE_TEMPLATE/feature_request.yml
+---
+name: 🚀 Feature Request
+description: Suggest a new feature for this project.
+labels: 'template: feature'
+body:
+- type: markdown
+  attributes:
+    value: |
+      **Thanks for taking a minute to file a feature for deck-viewer!**
+
+      Verify first that your issue is not [already reported on GitHub][issue search].
+
+      _Please fill out the form below with as many precise
+      details as possible._
+
+      [issue search]: ../search?q=is%3Aissue&type=issues
+
+- type: textarea
+  attributes:
+    label: Describe the feature you'd like to request
+    description: A clear and concise description of what you want and what your use case is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Describe the solution you'd like
+    description: A clear and concise description of what you want to happen.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: true
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Adventure Cards Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/Adventure-Cards/deck-viewer/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the Adventure Cards Code of Conduct
+      required: true
+...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+Thanks for opening a PR! Your contribution is much appreciated.
+In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
+Choose the right checklist for the change that you're making:
+-->
+
+## 🐛 Bug Fix
+
+- [ ] Related issues linked using `fixes #number`
+- [ ] Resolved errors have before and after documentation
+- [ ] Integration tests updated (if applicable)
+
+
+## 🚀 New Feature
+
+- [ ] Implements an existing feature request or builds out a new idea
+- [ ] Related issues linked using `fixes #number`
+- [ ] Integration tests added
+- [ ] Documentation added
+
+
+## Documentation
+
+- [ ] See `contributing.md`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at 0xolias@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,43 @@
+# Contributing to Deck Viewer
+
+We welcome new contributors and contributions both large and small!
+
+## Developing
+
+The development branch is `main`, and this is the branch that all pull
+requests should be made against.
+
+To develop locally:
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your
+   own GitHub account and then
+   [clone](https://help.github.com/articles/cloning-a-repository/) it to your
+   local device.
+2. Create a new branch:
+   ```
+   git checkout -b MY_BRANCH_NAME
+   ```
+3. Install yarn:
+   ```
+   npm install -g yarn
+   ```
+4. Install the dependencies with:
+   ```
+   yarn
+   ```
+5. Start developing and watch for code changes:
+   ```
+   yarn dev
+   ```
+
+## Building
+
+You can build the project with:
+
+```bash
+yarn build
+# - or -
+yarn prepublish
+```
+
+If you need to clean the project for any reason, use `yarn clean`.


### PR DESCRIPTION
## Background

This PR adds contribution guides and templates to encourage community contributions.

## Changes

### Adds
-  `contributing.md`
-  `CODE_OF_CONDUCT.md`
- `.github/pull_request_template.md`
-  `.github/ISSUE_TEMPLATE/config.yml`
-  `github/ISSUE_TEMPLATE/feature_request.yml`
-  `.github/ISSUE_TEMPLATE/bug_report.yml`